### PR TITLE
Python 3 Compatibility and Relative Module Imports

### DIFF
--- a/eatiht/__init__.py
+++ b/eatiht/__init__.py
@@ -99,5 +99,5 @@ github - https://github.com/rodricios/eatiht
 
 
 from .eatiht import extract, get_sentence_xpath_tuples, get_xpath_frequencydistribution
-import eatiht_trees
-import etv2
+from . import eatiht_trees
+from . import etv2

--- a/eatiht/eatiht.py
+++ b/eatiht/eatiht.py
@@ -70,15 +70,19 @@ github - https://github.com/im-rodrigo
 """
 
 import re
-import urllib2
-import cookielib
 import chardet
 
 from collections import Counter
+
 try:
     from cStringIO import StringIO as BytesIO
+    from urllib2 import HTTPHandler, HTTPSHandler, build_opener, HTTPCookieProcessor
+    from cookielib import CookieJar
 except ImportError:
     from io import BytesIO
+    from urllib.request import HTTPHandler, HTTPSHandler, build_opener, HTTPCookieProcessor
+    from http.cookiejar import CookieJar
+
 
 from lxml import html
 
@@ -125,14 +129,14 @@ def get_html_tree(filename_url_or_filelike):
     """
     try:
         handler = (
-            urllib2.HTTPSHandler
+            HTTPSHandler
                 if filename_url_or_filelike.lower().startswith('https')
-                else urllib2.HTTPHandler
+                else HTTPHandler
         )
-        cj = cookielib.CookieJar()
-        opener = urllib2.build_opener(handler)
-        opener.add_handler(urllib2.HTTPCookieProcessor(cj))
-        
+        cj = CookieJar()
+        opener = build_opener(handler)
+        opener.add_handler(HTTPCookieProcessor(cj))
+
         resp = opener.open(filename_url_or_filelike)
     except(AttributeError):
         content = filename_url_or_filelike.read()
@@ -141,7 +145,7 @@ def get_html_tree(filename_url_or_filelike):
         parsed_html = html.parse(BytesIO(content),
                                  html.HTMLParser(encoding=encoding,
                                                  remove_blank_text=True))
-        
+
         return parsed_html
     except(ValueError):
         content = filename_url_or_filelike
@@ -150,7 +154,7 @@ def get_html_tree(filename_url_or_filelike):
         parsed_html = html.parse(BytesIO(content),
                                  html.HTMLParser(encoding=encoding,
                                                  remove_blank_text=True))
-        
+
         return parsed_html
 
     try:

--- a/eatiht/etv2.py
+++ b/eatiht/etv2.py
@@ -80,21 +80,23 @@ as to what exactly it is that I'm doing lol.
 """
 
 
-import urllib2
-import cookielib
 import chardet
 
 from collections import Counter
 
 try:
     from cStringIO import StringIO as BytesIO
+    from urllib2 import HTTPHandler, HTTPSHandler, build_opener, HTTPCookieProcessor
+    from cookielib import CookieJar
 except ImportError:
     from io import BytesIO
+    from urllib.request import HTTPHandler, HTTPSHandler, build_opener, HTTPCookieProcessor
+    from http.cookiejar import CookieJar
 
 from lxml import html
 from lxml.html.clean import Cleaner
 
-from eatiht_trees import TextNodeSubTree, TextNodeTree
+from .eatiht_trees import TextNodeSubTree, TextNodeTree
 
 # decided to use backslashes for readability?
 TEXT_FINDER_XPATH = '//body\
@@ -131,13 +133,13 @@ def get_html_tree(filename_url_or_filelike):
     """
     try:
         handler = (
-            urllib2.HTTPSHandler
+            HTTPSHandler
                 if filename_url_or_filelike.lower().startswith('https')
-                else urllib2.HTTPHandler
+                else HTTPHandler
         )
-        cj = cookielib.CookieJar()
-        opener = urllib2.build_opener(handler)
-        opener.add_handler(urllib2.HTTPCookieProcessor(cj))
+        cj = CookieJar()
+        opener = build_opener(handler)
+        opener.add_handler(HTTPCookieProcessor(cj))
 
         resp = opener.open(filename_url_or_filelike)
     except(AttributeError):

--- a/eatiht/v2.py
+++ b/eatiht/v2.py
@@ -79,15 +79,18 @@ classically trained in this sort of thing so I'd appreciate any insight
 as to what exactly it is that I'm doing lol.
 """
 
-import urllib2
-import cookielib
 import chardet
 
 from collections import Counter
+
 try:
     from cStringIO import StringIO as BytesIO
+    from urllib2 import HTTPHandler, HTTPSHandler, build_opener, HTTPCookieProcessor
+    from cookielib import CookieJar
 except ImportError:
     from io import BytesIO
+    from urllib.request import HTTPHandler, HTTPSHandler, build_opener, HTTPCookieProcessor
+    from http.cookiejar import CookieJar
 
 from lxml import html
 #from lxml.html.clean import Cleaner TODO!
@@ -112,13 +115,13 @@ def get_html_tree(filename_url_or_filelike):
     """
     try:
         handler = (
-            urllib2.HTTPSHandler
+            HTTPSHandler
                 if filename_url_or_filelike.lower().startswith('https')
-                else urllib2.HTTPHandler
+                else HTTPHandler
         )
-        cj = cookielib.CookieJar()
-        opener = urllib2.build_opener(handler)
-        opener.add_handler(urllib2.HTTPCookieProcessor(cj))
+        cj = CookieJar()
+        opener = build_opener(handler)
+        opener.add_handler(HTTPCookieProcessor(cj))
 
         resp = opener.open(filename_url_or_filelike)
     except(AttributeError):


### PR DESCRIPTION
Hey Rodrigo

So your library doesn't work on Python 3 and you use both relative and absolute imports in your module. This might work for you since you have your library installed, but it won't work for people who are installing your package.

I've patched up both of these issues in this PR.

Also I might recommend some refactoring so there is less code duplication in your packages. That way, you only need to patch up one location rather than 3.